### PR TITLE
Updates

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,3 +6,4 @@
 ^pkgdown$
 ^\.github$
 ^data-raw$
+^inst/models/GAM_smooth_model$

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -30,10 +30,22 @@ jobs:
         with:
           use-public-rspm: true
 
+      - name: Repos
+        run: |
+          cat("\noptions(repos=c(stan='https://mc-stan.org/r-packages/',CRAN ='https://cloud.r-project.org'))\n", file = "~/.Rprofile", append = TRUE)
+        shell: Rscript {0}
+
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::pkgdown, local::.
+          extra-packages: any::pkgdown, local::., any::cmdstanr
           needs: website
+          cache-version: 2
+
+      - name: Install CmdStan
+        shell: Rscript {0}
+        run: |
+          cmdstanr::check_cmdstan_toolchain(fix = TRUE)
+          cmdstanr::install_cmdstan()
 
       - name: Build site
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@
 .quarto
 inst/doc
 docs
-inst/models
+inst/models/GAM_smooth_model

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,11 +15,11 @@ BugReports: https://github.com/ninoxconsulting/birdtrends/issues
 Suggests: 
     knitr,
     rmarkdown,
-    testthat (>= 3.0.0)
+    testthat (>= 3.0.0),
+    cmdstanr
 Config/testthat/edition: 3
 Imports: 
     broom,
-    cmdstanr,
     devtools,
     dplyr,
     foreach,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,7 @@ Imports:
     tibble,
     tidyr,
     utils
-Remotes: https://mc-stan.org/r-packages/
+Additional_repositories: https://mc-stan.org/r-packages/
 SystemRequirements: CmdStan (https://mc-stan.org/users/interfaces/cmdstan)
 VignetteBuilder: knitr
 Depends: 

--- a/R/fit_hgam.R
+++ b/R/fit_hgam.R
@@ -14,6 +14,11 @@
 #'}
 fit_hgam <- function(indata, start_yr = NA, end_yr = NA,  n_knots = 5){
 
+  if (!requireNamespace("cmdstanr", quietly = TRUE)) {
+    stop('You need to install the cmdstanr package; install with: 
+  install.packages("cmdstanr", repos = c("https://mc-stan.org/r-packages/", getOption("repos")))')
+  }
+
   # testing
   # indata = indat1
   # start_yr = NA#1990

--- a/vignettes/Getting_started.Rmd
+++ b/vignettes/Getting_started.Rmd
@@ -14,26 +14,34 @@ knitr::opts_chunk$set(
 )
 ```
 
-```{r setup}
-#library(birdtrends)
-
-```
-
 The birdtrends package enables users to estimate trends of populations into the future based on a variety of input data types. 
 
 # Getting set-up 
 
-1) Download birdtrends
+1) Install birdtrends
+
+```{r, eval=FALSE}
+remotes::install_github("ninoxconsulting/birdtrends")
+```
 2) Set up modelling connections. 
 
-
-In order to run all of the model options, you will need to install and set up packages to enable models to be run using [Stan](https://mc-stan.org/). 
-
-You can find a set of excellent installation instructions in the bbsBayes package [here](https://bbsbayes.github.io/bbsBayes2/articles/bbsBayes2.html).
+The birdtrends package uses the cmdstanr package to run the hierarchical GAM models using [Stan](https://mc-stan.org/). We can install cmdstanr with:
 
 ```{r}
 install.packages("cmdstanr", repos = c("https://mc-stan.org/r-packages/",
                                        getOption("repos")))
+```
+
+The cmdstanr package in turn requires the `cmdstan` program to run Stan programs. You can use the `cmdstanr` package to `cmdstan`:
+
+```{r}
+cmdstanr::install_cmdstan()
+```
+
+And then check that `cmdstan` was installed properly:
+
+```{r}
+cmdstanr::check_cmdstan_toolchain()
 ```
 
 # What dataset can be used? 

--- a/vignettes/Getting_started.Rmd
+++ b/vignettes/Getting_started.Rmd
@@ -27,20 +27,20 @@ remotes::install_github("ninoxconsulting/birdtrends")
 
 The birdtrends package uses the cmdstanr package to run the hierarchical GAM models using [Stan](https://mc-stan.org/). We can install cmdstanr with:
 
-```{r}
+```{r, eval=FALSE}
 install.packages("cmdstanr", repos = c("https://mc-stan.org/r-packages/",
                                        getOption("repos")))
 ```
 
 The cmdstanr package in turn requires the `cmdstan` program to run Stan programs. You can use the `cmdstanr` package to `cmdstan`:
 
-```{r}
+```{r, eval=FALSE}
 cmdstanr::install_cmdstan()
 ```
 
 And then check that `cmdstan` was installed properly:
 
-```{r}
+```{r, eval=FALSE}
 cmdstanr::check_cmdstan_toolchain()
 ```
 

--- a/vignettes/Using-annual-indices-datasets.Rmd
+++ b/vignettes/Using-annual-indices-datasets.Rmd
@@ -2,7 +2,7 @@
 title: "Use annual indices and uncertainty to estimate trends over time"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Use Annual indices and uncertaintly to estimate trends over time}
+  %\VignetteIndexEntry{Use annual indices and uncertainty to estimate trends over time}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---

--- a/vignettes/Using-annual-indices-datasets.Rmd
+++ b/vignettes/Using-annual-indices-datasets.Rmd
@@ -25,20 +25,12 @@ Note: this vignette assumes you had already followed the steps outlined [here](h
 Lets start by loading all the libraries required.
 
 ```{r setup, warning = FALSE, message =FALSE}
-devtools::load_all()
 library(birdtrends)
 library(ggplot2)
 library(mgcv)
 library(dplyr)
 library(tidyr)
-
-install.packages("cmdstanr", repos = c("https://mc-stan.org/r-packages/",
-                                       getOption("repos")))
-
-
-
 ```
-
 
 ## 2. Model the annual indices based on input data of observed annual indices. 
 


### PR DESCRIPTION
Hey @gcperk - some changes to make this work:

- DESCRIPTION: Moved cmdstanr to Suggests, put repo in `Additional_repositories` rather than `Remotes`
- Add check for installation of cmdstanr in `fit_hgam()` with prompt to install it if fails
- Added the compiled stan model to both `.*ignore` files so it doesn't get committed, and gets ignored during R CMD check
- Added instructions for installing both `cmdstanr` and `cmdstan` to getting started Vignette

With this, for me R CMD check runs cleanly except for the NOTEs about undeclared global variables. Also, if I run the Getting Started vignette first, then the second vignette runs without issue.